### PR TITLE
Fix #29: handling of unknown frame disposal method

### DIFF
--- a/NuGet/XamlAnimatedGif.nuspec
+++ b/NuGet/XamlAnimatedGif.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>XamlAnimatedGif</id>
     <title>XAML Animated GIF</title>
-    <version>1.0.3</version>
+    <version>1.0.4</version>
     <summary>A simple library to display animated GIF images in XAML applications</summary>
     <description>A simple library to display animated GIF images in XAML applications. Currently supported platforms include WPF (.NET 4.5), Windows 8.1 and Windows Phone 8.1.</description>
     <authors>Thomas Levesque</authors>
@@ -13,6 +13,7 @@
     <iconUrl>https://raw.githubusercontent.com/XamlAnimatedGif/XamlAnimatedGif/master/NuGet/XamlAnimatedGif-128.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <releaseNotes xml:space="preserve">
+- 1.0.4: Fixed #29: handling of unknown frame disposal method
 - 1.0.3: Fixed memory leak when animation source is changed before previous animation is completely loaded
 - 1.0.2: Fixed bug in Animator.Dispose where Cancel was called on the wrong CancellationTokenSource
 - 1.0.1: Fixed LZW decoding issue in some optimized images when the code table is full (#19)

--- a/XamlAnimatedGif.Shared/Animator.cs
+++ b/XamlAnimatedGif.Shared/Animator.cs
@@ -441,10 +441,6 @@ namespace XamlAnimatedGif
 #endif
                         break;
                     }
-                    default:
-                    {
-                        throw new ArgumentOutOfRangeException();
-                    }
                 }
             }
 

--- a/XamlAnimatedGif.Shared/Properties/VersionInfo.cs
+++ b/XamlAnimatedGif.Shared/Properties/VersionInfo.cs
@@ -9,7 +9,7 @@ namespace XamlAnimatedGif.Properties
 {
     class VersionInfo
     {
-        public const string Version = "1.0.3.0";
+        public const string Version = "1.0.4.0";
         public const string PreRelease = "";
     }
 }


### PR DESCRIPTION
Process unknown FrameDisposal values same as None, rather than throw an
exception.