### PR TITLE
Fix wrong dependency version in nuspec for .NET 4

### DIFF
--- a/NuGet/XamlAnimatedGif.nuspec
+++ b/NuGet/XamlAnimatedGif.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>XamlAnimatedGif</id>
     <title>XAML Animated GIF</title>
-    <version>1.0.5</version>
+    <version>1.0.6</version>
     <summary>A simple library to display animated GIF images in XAML applications</summary>
     <description>A simple library to display animated GIF images in XAML applications. Currently supported platforms include WPF (.NET 4.5), Windows 8.1 and Windows Phone 8.1.</description>
     <authors>Thomas Levesque</authors>
@@ -13,6 +13,7 @@
     <iconUrl>https://raw.githubusercontent.com/XamlAnimatedGif/XamlAnimatedGif/master/NuGet/XamlAnimatedGif-128.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <releaseNotes xml:space="preserve">
+- 1.0.6: Fixed #27: wrong dependency version for .NET 4.0
 - 1.0.5: Fixed #27: leaked Animator instances when the Image is unloaded or never loaded
 - 1.0.4: Fixed #29: handling of unknown frame disposal method
 - 1.0.3: Fixed memory leak when animation source is changed before previous animation is completely loaded
@@ -35,7 +36,7 @@
       </group>
       <group targetFramework="net40">
         <dependency id="Microsoft.Bcl.Async" version="1.0.168" />
-        <dependency id="Microsoft.Net.Http" version="2.2.28" />
+        <dependency id="Microsoft.Net.Http" version="2.2.29" />
       </group>
     </dependencies>
   </metadata>

--- a/XamlAnimatedGif.Shared/Properties/VersionInfo.cs
+++ b/XamlAnimatedGif.Shared/Properties/VersionInfo.cs
@@ -9,7 +9,7 @@ namespace XamlAnimatedGif.Properties
 {
     class VersionInfo
     {
-        public const string Version = "1.0.5.0";
+        public const string Version = "1.0.6.0";
         public const string PreRelease = "";
     }
 }


### PR DESCRIPTION
The library was referencing Microsoft.Net.Http 2.2.29, but the nuspec
still referred to 2.2.28.