### PR TITLE
Fix #37: error when starting animation manually

### DIFF
--- a/NuGet/XamlAnimatedGif.nuspec
+++ b/NuGet/XamlAnimatedGif.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>XamlAnimatedGif</id>
     <title>XAML Animated GIF</title>
-    <version>1.0.6</version>
+    <version>1.0.7</version>
     <summary>A simple library to display animated GIF images in XAML applications</summary>
     <description>A simple library to display animated GIF images in XAML applications. Currently supported platforms include WPF (.NET 4.5), Windows 8.1 and Windows Phone 8.1.</description>
     <authors>Thomas Levesque</authors>
@@ -13,6 +13,7 @@
     <iconUrl>https://raw.githubusercontent.com/XamlAnimatedGif/XamlAnimatedGif/master/NuGet/XamlAnimatedGif-128.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <releaseNotes xml:space="preserve">
+- 1.0.7: Fixed #37: fix error when AutoStart is false and animation is started manually from the Loaded event handler
 - 1.0.6: Fixed #27: wrong dependency version for .NET 4.0
 - 1.0.5: Fixed #27: leaked Animator instances when the Image is unloaded or never loaded
 - 1.0.4: Fixed #29: handling of unknown frame disposal method

--- a/XamlAnimatedGif.Shared/AnimationBehavior.cs
+++ b/XamlAnimatedGif.Shared/AnimationBehavior.cs
@@ -1,6 +1,7 @@
 ﻿using XamlAnimatedGif.Decoding;
 using System;
 using System.IO;
+using System.Threading.Tasks;
 #if WPF
 using System.ComponentModel;
 using System.Windows;
@@ -407,7 +408,7 @@ namespace XamlAnimatedGif
                     animator.Dispose();
                     return;
                 }
-                SetAnimatorCore(image, animator);
+                await SetAnimatorCoreAsync(image, animator);
                 OnLoaded(image);
             }
             catch (InvalidSignatureException)
@@ -429,7 +430,7 @@ namespace XamlAnimatedGif
             try
             {
                 var animator = await Animator.CreateAsync(image, stream, repeatBehavior);
-                SetAnimatorCore(image, animator);
+                await SetAnimatorCoreAsync(image, animator);
                 // Check that the source hasn't changed while we were loading the animation
                 if (GetSeqNum(image) != seqNum)
                 {
@@ -457,14 +458,14 @@ namespace XamlAnimatedGif
             }
         }
 
-        private static void SetAnimatorCore(Image image, Animator animator)
+        private static async Task SetAnimatorCoreAsync(Image image, Animator animator)
         {
             SetAnimator(image, animator);
             image.Source = animator.Bitmap;
             if (GetAutoStart(image))
                 animator.Play();
             else
-                animator.ShowFirstFrame();
+                await animator.ShowFirstFrameAsync();
         }
 
         private static void ClearAnimatorCore(Image image)

--- a/XamlAnimatedGif.Shared/Animator.cs
+++ b/XamlAnimatedGif.Shared/Animator.cs
@@ -554,7 +554,7 @@ namespace XamlAnimatedGif
             public Color this[int i] => _colors[i];
         }
 
-        internal async void ShowFirstFrame()
+        internal async Task ShowFirstFrameAsync()
         {
             try
             {

--- a/XamlAnimatedGif.Shared/Properties/VersionInfo.cs
+++ b/XamlAnimatedGif.Shared/Properties/VersionInfo.cs
@@ -9,7 +9,7 @@ namespace XamlAnimatedGif.Properties
 {
     class VersionInfo
     {
-        public const string Version = "1.0.6.0";
+        public const string Version = "1.0.7.0";
         public const string PreRelease = "";
     }
 }

--- a/build.cake
+++ b/build.cake
@@ -1,3 +1,5 @@
+#tool "NUnit.Runners"
+
 using System.Xml.Linq;
 
 ////////////////////
@@ -75,9 +77,17 @@ Task("Clean")
     CleanDirectory(nugetDir);
 });
 
+// Restores NuGet packages
+Task("Restore")
+    .Does(() =>
+{
+    NuGetRestore(solutionFile);
+});
+
 // Builds the solution
 Task("Build")
     .IsDependentOn("Clean")
+    .IsDependentOn("Restore")
     .Does(() =>
 {
     foreach (var project in projects)

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<packages>
-    <package id="Cake" version="0.5.1" />
-    <package id="NUnit.Runners" version="2.6.4" />
-</packages>


### PR DESCRIPTION
When AutoStart is false and Play is called immediately when Loaded is
raised, the image fails to render.

Fix: wait until the first frame is rendered before raising Loaded.