### PR TITLE
Fixed dirty rect size on some images

### DIFF
--- a/XamlAnimatedGif.Shared/Animator.cs
+++ b/XamlAnimatedGif.Shared/Animator.cs
@@ -346,7 +346,7 @@ namespace XamlAnimatedGif
                         CopyToBitmap(lineBuffer, _bitmap, offset, bufferLength);
                     }
 #if WPF
-                    var rect = new Int32Rect(desc.Left, desc.Top, desc.Width, desc.Height);
+                    var rect = new Int32Rect(desc.Left, desc.Top, desc.Width - desc.Left, desc.Height - desc.Top);
                     _bitmap.AddDirtyRect(rect);
                 }
                 finally
@@ -475,7 +475,7 @@ namespace XamlAnimatedGif
                 CopyToBitmap(lineBuffer, _bitmap, offset, bufferLength);
             }
 #if WPF
-            _bitmap.AddDirtyRect(new Int32Rect(rect.Left, rect.Top, rect.Width, rect.Height));
+            _bitmap.AddDirtyRect(new Int32Rect(rect.Left, rect.Top, rect.Width - rect.Left, rect.Height - rect.Top));
 #endif
         }
 


### PR DESCRIPTION
Some gifs throws System.ArgumentException when setting a dirty rect (dimension is bigger than image's frame).
For example of a broken image check out this [gif](https://cdn.betterttv.net/emote/55ae376ed5e0264366129a7d/1x).