### PR TITLE
Fix false EndOfStreamException

### DIFF
--- a/XamlAnimatedGif.Shared/Animator.cs
+++ b/XamlAnimatedGif.Shared/Animator.cs
@@ -332,9 +332,7 @@ namespace XamlAnimatedGif
 
                     foreach (int y in rows)
                     {
-                        int read = indexStream.Read(indexBuffer, 0, desc.Width);
-                        if (read != desc.Width)
-                            throw new EndOfStreamException();
+                        indexStream.ReadAll(indexBuffer, 0, desc.Width);
 
                         int offset = (desc.Top + y) * _stride + desc.Left * 4;
 


### PR DESCRIPTION
Stream.Read isn't guaranteed to read the specified number of bytes; if
it reads less bytes than specified, it doesn't mean we reached the end
of the stream. Use the ReadAll extension instead, which will keep
reading until the specified number of bytes has been read.

Fixes #105 (at least partially)