### PR TITLE
Only open the cached file once

### DIFF
--- a/XamlAnimatedGif/UriLoader.cs
+++ b/XamlAnimatedGif/UriLoader.cs
@@ -27,11 +27,11 @@ namespace XamlAnimatedGif
             if (cacheStream == null)
             {
                 await DownloadToCacheFileAsync(uri, cacheFileName, progress);
+                cacheStream = await OpenTempFileStreamAsync(cacheFileName);
             }
             progress.Report(100);
-            return await OpenTempFileStreamAsync(cacheFileName);
+            return cacheStream;
         }
-
         private static async Task DownloadToCacheFileAsync(Uri uri, string fileName, IProgress<int> progress)
         {
             try


### PR DESCRIPTION
OpenTempFileStreamAsync is currently called twice, but only needs to be called once when the cached file exists.