### PR TITLE
Fix deleting temp file not using full path. 

### DIFF
--- a/XamlAnimatedGif/UriLoader.cs
+++ b/XamlAnimatedGif/UriLoader.cs
@@ -59,7 +59,7 @@ namespace XamlAnimatedGif
             }
             catch
             {
-                await DeleteTempFileAsync(fileName);
+                DeleteTempFile(fileName);
                 throw;
             }
         }
@@ -108,11 +108,11 @@ namespace XamlAnimatedGif
             return Task.FromResult(stream);
         }
 
-        private static Task DeleteTempFileAsync(string fileName)
+        private static void DeleteTempFile(string fileName)
         {
-            if (File.Exists(fileName))
-                File.Delete(fileName);
-            return Task.FromResult(fileName);
+            string path = Path.Combine(Path.GetTempPath(), fileName);
+            if (File.Exists(path))
+                File.Delete(path);
         }
 
         private static string GetCacheFileName(Uri uri)


### PR DESCRIPTION
The filename is passed around and most methods then prefix it with the Temp folder, but DeleteTempFileAsync wasn't. Instead, it was incorrectly trying to delete the file from the current folder rather than the temp folder. Note: I'm not addressing it in this PR, but I'd recommend passing the full path around rather than the file name to avoid inconsistencies like this. 

Removed unnecessary and inconsistent Task from signature and Task<string> return statement. I did this because the return value wasn't used, what to return is questionable given the above bug; there weren't any await calls in the method; and no interface with a Task return to satisfy. Note: I'm not addressing it in this PR but I also saw some other unnecessary methods with a Task<T> return and Async name suffix that could do with a tidy-up.