### PR TITLE
Make Double Pause and Double Resume a No-op.

### DIFF
--- a/XamlAnimatedGif/TimingManager.cs
+++ b/XamlAnimatedGif/TimingManager.cs
@@ -101,12 +101,14 @@ namespace XamlAnimatedGif
         private TaskCompletionSource<int> _pauseCompletionSource;
         public void Pause()
         {
+            if (IsPaused) return; // Make this a no-op.
             IsPaused = true;
             _pauseCompletionSource = new TaskCompletionSource<int>();
         }
 
         public void Resume()
         {
+            if (!IsPaused) return; // Make this a no-op.
             var tcs = _pauseCompletionSource;
             tcs?.TrySetResult(0);
             _pauseCompletionSource = null;


### PR DESCRIPTION
This fixes bug https://github.com/XamlAnimatedGif/XamlAnimatedGif/issues/170  

Calling pause twice dereferences an active TaskCompletionSource

By checking for and completing the TaskCompletionSource before creating a new one, we don't double stop the async thread if someone makes an error and calls pause twice.

This fixes Issue: https://github.com/XamlAnimatedGif/XamlAnimatedGif/issues/170 https://github.com/XamlAnimatedGif/XamlAnimatedGif/issues/170

From the discussion section of the bug;

I'll do a pull request on the first of the expected behavior; _animator.Play(); resumes animation even if you have paused it twice.

Sure, someone can implement a Boolean, or check _animator.IsPaused first to know if the animation is already paused, however, the documentation isn't clear enough to know that you must do that and calling a double Pause would break the threading model.

When it doesn't work, it's really tough for someone figure out why calling resume isn't working. I just assumed that it was buggy for several months and tried to use it as little as possible.

There isn't any message or other notification that you broke it.

Furthermore, in other frameworks, if you call pause twice or resume twice, the result is it pauses or resumes respectively. The double action is a no-op.

This is the second attempt at the PR after the maintainer requested changes.  Instead of clearing the TaskCompletionSource before making a new one, we're just checking for if the video IsPaused in the Pause and Resume methods returning per guidance by the maintainer. 