### PR TITLE
option to cache frames data in memory

### DIFF
--- a/XamlAnimatedGif/Animator.cs
+++ b/XamlAnimatedGif/Animator.cs
@@ -344,7 +344,7 @@ namespace XamlAnimatedGif
             {
                 indexStream = await GetIndexStreamAsync(frame, cancellationToken);
             }
-            await using (indexStream);
+            using (indexStream);
             using (_bitmap.LockInScope())
             {
                 if (frameIndex < _previousFrameIndex)

--- a/XamlAnimatedGif/BrushAnimator.cs
+++ b/XamlAnimatedGif/BrushAnimator.cs
@@ -9,7 +9,7 @@ namespace XamlAnimatedGif
 {
     public class BrushAnimator : Animator
     {
-        private BrushAnimator(Stream sourceStream, Uri sourceUri, GifDataStream metadata, RepeatBehavior repeatBehavior) : base(sourceStream, sourceUri, metadata, repeatBehavior)
+        private BrushAnimator(Stream sourceStream, Uri sourceUri, GifDataStream metadata, RepeatBehavior repeatBehavior, bool cacheFrameDataInMemory) : base(sourceStream, sourceUri, metadata, repeatBehavior, cacheFrameDataInMemory)
         {
             Brush = new ImageBrush {ImageSource = Bitmap};
             RepeatBehavior = _repeatBehavior;
@@ -32,19 +32,19 @@ namespace XamlAnimatedGif
             }
         }
 
-        public static Task<BrushAnimator> CreateAsync(Uri sourceUri, RepeatBehavior repeatBehavior, IProgress<int> progress = null)
+        public static Task<BrushAnimator> CreateAsync(Uri sourceUri, RepeatBehavior repeatBehavior, bool cacheFrameDataInMemory, IProgress<int> progress = null)
         {
             return CreateAsyncCore(
                 sourceUri,
                 progress,
-                (stream, metadata) => new BrushAnimator(stream, sourceUri, metadata, repeatBehavior));
+                (stream, metadata) => new BrushAnimator(stream, sourceUri, metadata, repeatBehavior, cacheFrameDataInMemory));
         }
 
-        public static Task<BrushAnimator> CreateAsync(Stream sourceStream, RepeatBehavior repeatBehavior)
+        public static Task<BrushAnimator> CreateAsync(Stream sourceStream, RepeatBehavior repeatBehavior, bool cacheFrameDataInMemory)
         {
             return CreateAsyncCore(
                 sourceStream,
-                metadata => new BrushAnimator(sourceStream, null, metadata, repeatBehavior));
+                metadata => new BrushAnimator(sourceStream, null, metadata, repeatBehavior, cacheFrameDataInMemory));
         }
     }
 }

--- a/XamlAnimatedGif/BrushAnimator.cs
+++ b/XamlAnimatedGif/BrushAnimator.cs
@@ -32,7 +32,7 @@ namespace XamlAnimatedGif
             }
         }
 
-        public static Task<BrushAnimator> CreateAsync(Uri sourceUri, RepeatBehavior repeatBehavior, bool cacheFrameDataInMemory, IProgress<int> progress = null)
+        public static Task<BrushAnimator> CreateAsync(Uri sourceUri, RepeatBehavior repeatBehavior, bool cacheFrameDataInMemory = false, IProgress<int> progress = null)
         {
             return CreateAsyncCore(
                 sourceUri,
@@ -40,7 +40,7 @@ namespace XamlAnimatedGif
                 (stream, metadata) => new BrushAnimator(stream, sourceUri, metadata, repeatBehavior, cacheFrameDataInMemory));
         }
 
-        public static Task<BrushAnimator> CreateAsync(Stream sourceStream, RepeatBehavior repeatBehavior, bool cacheFrameDataInMemory)
+        public static Task<BrushAnimator> CreateAsync(Stream sourceStream, RepeatBehavior repeatBehavior, bool cacheFrameDataInMemory = false)
         {
             return CreateAsyncCore(
                 sourceStream,

--- a/XamlAnimatedGif/BrushAnimator.cs
+++ b/XamlAnimatedGif/BrushAnimator.cs
@@ -32,7 +32,12 @@ namespace XamlAnimatedGif
             }
         }
 
-        public static Task<BrushAnimator> CreateAsync(Uri sourceUri, RepeatBehavior repeatBehavior, bool cacheFrameDataInMemory = false, IProgress<int> progress = null)
+        public static Task<BrushAnimator> CreateAsync(Uri sourceUri, RepeatBehavior repeatBehavior, IProgress<int> progress = null)
+        {
+            return CreateAsync(sourceUri, repeatBehavior, false, progress);
+        }
+
+        public static Task<BrushAnimator> CreateAsync(Uri sourceUri, RepeatBehavior repeatBehavior, bool cacheFrameDataInMemory, IProgress<int> progress = null)
         {
             return CreateAsyncCore(
                 sourceUri,
@@ -40,7 +45,12 @@ namespace XamlAnimatedGif
                 (stream, metadata) => new BrushAnimator(stream, sourceUri, metadata, repeatBehavior, cacheFrameDataInMemory));
         }
 
-        public static Task<BrushAnimator> CreateAsync(Stream sourceStream, RepeatBehavior repeatBehavior, bool cacheFrameDataInMemory = false)
+        public static Task<BrushAnimator> CreateAsync(Stream sourceStream, RepeatBehavior repeatBehavior)
+        {
+            return CreateAsync(sourceStream, repeatBehavior, false);
+        }
+
+        public static Task<BrushAnimator> CreateAsync(Stream sourceStream, RepeatBehavior repeatBehavior, bool cacheFrameDataInMemory)
         {
             return CreateAsyncCore(
                 sourceStream,

--- a/XamlAnimatedGif/ImageAnimator.cs
+++ b/XamlAnimatedGif/ImageAnimator.cs
@@ -11,7 +11,7 @@ namespace XamlAnimatedGif
     {
         private readonly Image _image;
 
-        public ImageAnimator(Stream sourceStream, Uri sourceUri, GifDataStream metadata, RepeatBehavior repeatBehavior, Image image) : base(sourceStream, sourceUri, metadata, repeatBehavior)
+        public ImageAnimator(Stream sourceStream, Uri sourceUri, GifDataStream metadata, RepeatBehavior repeatBehavior, Image image, bool cacheFrameDataInMemory) : base(sourceStream, sourceUri, metadata, repeatBehavior, cacheFrameDataInMemory)
         {
             _image = image;
             OnRepeatBehaviorChanged(); // in case the value has changed during creation
@@ -21,19 +21,19 @@ namespace XamlAnimatedGif
 
         protected override object AnimationSource => _image;
 
-        public static Task<ImageAnimator> CreateAsync(Uri sourceUri, RepeatBehavior repeatBehavior, IProgress<int> progress, Image image)
+        public static Task<ImageAnimator> CreateAsync(Uri sourceUri, RepeatBehavior repeatBehavior, IProgress<int> progress, Image image, bool cacheFrameDataInMemory)
         {
             return CreateAsyncCore(
                 sourceUri,
                 progress,
-                (stream, metadata) => new ImageAnimator(stream, sourceUri, metadata, repeatBehavior, image));
+                (stream, metadata) => new ImageAnimator(stream, sourceUri, metadata, repeatBehavior, image, cacheFrameDataInMemory));
         }
 
-        public static Task<ImageAnimator> CreateAsync(Stream sourceStream, RepeatBehavior repeatBehavior, Image image)
+        public static Task<ImageAnimator> CreateAsync(Stream sourceStream, RepeatBehavior repeatBehavior, Image image, bool cacheFrameDataInMemory)
         {
             return CreateAsyncCore(
                 sourceStream,
-                metadata => new ImageAnimator(sourceStream, null, metadata, repeatBehavior, image));
+                metadata => new ImageAnimator(sourceStream, null, metadata, repeatBehavior, image, cacheFrameDataInMemory));
         }
     }
 }

--- a/XamlAnimatedGif/ImageAnimator.cs
+++ b/XamlAnimatedGif/ImageAnimator.cs
@@ -11,7 +11,12 @@ namespace XamlAnimatedGif
     {
         private readonly Image _image;
 
-        public ImageAnimator(Stream sourceStream, Uri sourceUri, GifDataStream metadata, RepeatBehavior repeatBehavior, Image image, bool cacheFrameDataInMemory = false) : base(sourceStream, sourceUri, metadata, repeatBehavior, cacheFrameDataInMemory)
+        public ImageAnimator(Stream sourceStream, Uri sourceUri, GifDataStream metadata, RepeatBehavior repeatBehavior,
+            Image image) : this(sourceStream, sourceUri, metadata, repeatBehavior, image, false)
+        {
+        }
+
+        public ImageAnimator(Stream sourceStream, Uri sourceUri, GifDataStream metadata, RepeatBehavior repeatBehavior, Image image, bool cacheFrameDataInMemory) : base(sourceStream, sourceUri, metadata, repeatBehavior, cacheFrameDataInMemory)
         {
             _image = image;
             OnRepeatBehaviorChanged(); // in case the value has changed during creation
@@ -21,7 +26,12 @@ namespace XamlAnimatedGif
 
         protected override object AnimationSource => _image;
 
-        public static Task<ImageAnimator> CreateAsync(Uri sourceUri, RepeatBehavior repeatBehavior, IProgress<int> progress, Image image, bool cacheFrameDataInMemory = false)
+        public static Task<ImageAnimator> CreateAsync(Uri sourceUri, RepeatBehavior repeatBehavior, IProgress<int> progress, Image image)
+        {
+            return CreateAsync(sourceUri, repeatBehavior, progress, image, false);
+        }
+
+        public static Task<ImageAnimator> CreateAsync(Uri sourceUri, RepeatBehavior repeatBehavior, IProgress<int> progress, Image image, bool cacheFrameDataInMemory)
         {
             return CreateAsyncCore(
                 sourceUri,
@@ -29,7 +39,11 @@ namespace XamlAnimatedGif
                 (stream, metadata) => new ImageAnimator(stream, sourceUri, metadata, repeatBehavior, image, cacheFrameDataInMemory));
         }
 
-        public static Task<ImageAnimator> CreateAsync(Stream sourceStream, RepeatBehavior repeatBehavior, Image image, bool cacheFrameDataInMemory = false)
+        public static Task<ImageAnimator> CreateAsync(Stream sourceStream, RepeatBehavior repeatBehavior, Image image)
+        {
+            return CreateAsync(sourceStream, repeatBehavior, image);
+        }
+        public static Task<ImageAnimator> CreateAsync(Stream sourceStream, RepeatBehavior repeatBehavior, Image image, bool cacheFrameDataInMemory)
         {
             return CreateAsyncCore(
                 sourceStream,

--- a/XamlAnimatedGif/ImageAnimator.cs
+++ b/XamlAnimatedGif/ImageAnimator.cs
@@ -11,7 +11,7 @@ namespace XamlAnimatedGif
     {
         private readonly Image _image;
 
-        public ImageAnimator(Stream sourceStream, Uri sourceUri, GifDataStream metadata, RepeatBehavior repeatBehavior, Image image, bool cacheFrameDataInMemory) : base(sourceStream, sourceUri, metadata, repeatBehavior, cacheFrameDataInMemory)
+        public ImageAnimator(Stream sourceStream, Uri sourceUri, GifDataStream metadata, RepeatBehavior repeatBehavior, Image image, bool cacheFrameDataInMemory = false) : base(sourceStream, sourceUri, metadata, repeatBehavior, cacheFrameDataInMemory)
         {
             _image = image;
             OnRepeatBehaviorChanged(); // in case the value has changed during creation
@@ -21,7 +21,7 @@ namespace XamlAnimatedGif
 
         protected override object AnimationSource => _image;
 
-        public static Task<ImageAnimator> CreateAsync(Uri sourceUri, RepeatBehavior repeatBehavior, IProgress<int> progress, Image image, bool cacheFrameDataInMemory)
+        public static Task<ImageAnimator> CreateAsync(Uri sourceUri, RepeatBehavior repeatBehavior, IProgress<int> progress, Image image, bool cacheFrameDataInMemory = false)
         {
             return CreateAsyncCore(
                 sourceUri,
@@ -29,7 +29,7 @@ namespace XamlAnimatedGif
                 (stream, metadata) => new ImageAnimator(stream, sourceUri, metadata, repeatBehavior, image, cacheFrameDataInMemory));
         }
 
-        public static Task<ImageAnimator> CreateAsync(Stream sourceStream, RepeatBehavior repeatBehavior, Image image, bool cacheFrameDataInMemory)
+        public static Task<ImageAnimator> CreateAsync(Stream sourceStream, RepeatBehavior repeatBehavior, Image image, bool cacheFrameDataInMemory = false)
         {
             return CreateAsyncCore(
                 sourceStream,


### PR DESCRIPTION
added a CacheFramesInMemory property to AnimationBehavior that by default has 'false' value that when is set will load frames data into memory. I have done extensive testing and this changes helps to improve to avoid UI unresponsive when dealing with big gif files. 