### PR TITLE
Enhance animation behavior with cancellation and immediate frame rendering

### DIFF
--- a/XamlAnimatedGif/Animator.cs
+++ b/XamlAnimatedGif/Animator.cs
@@ -29,11 +29,13 @@ namespace XamlAnimatedGif
         private readonly TimingManager _timingManager;
         private readonly bool _cacheFrameDataInMemory;
         private readonly byte[][][] _cachedFrameBytes;
-        private readonly Task _loadFramesDataTask;
+		private TaskCompletionSource<bool> _frameLoadedEvent;
+		private readonly object _lockObject;
+
         #region Constructor and factory methods
 
         internal Animator(Stream sourceStream, Uri sourceUri, GifDataStream metadata, RepeatBehavior repeatBehavior,
-            bool cacheFrameDataInMemory)
+            bool cacheFrameDataInMemory, CancellationToken cancellationToken)
         {
             _sourceStream = sourceStream;
             _sourceUri = sourceUri;
@@ -51,12 +53,14 @@ namespace XamlAnimatedGif
 
             if (cacheFrameDataInMemory)
             {
+				_lockObject = new object();
+				_frameLoadedEvent = new TaskCompletionSource<bool>();
                 _cachedFrameBytes = new byte[_metadata.Frames.Count][][];
-                _loadFramesDataTask = Task.Run(LoadFrames);
+                Task.Run(()=>LoadFrames(cancellationToken));
             }
         }
 
-        private async Task LoadFrames()
+        private async Task LoadFrames(CancellationToken cancellationToken)
         {
             var biggestFrameSize = 0L;
             for (var frameIndex = 0; frameIndex < _metadata.Frames.Count; frameIndex++)
@@ -70,20 +74,35 @@ namespace XamlAnimatedGif
             }
 
             byte[] indexCompressedBytes = new byte[biggestFrameSize];
-            for (var frameIndex = 0; frameIndex < _metadata.Frames.Count; frameIndex++)
-            {
-                var frame = _metadata.Frames[frameIndex];
-                var frameDesc = _metadata.Frames[frameIndex].Descriptor;
-                await GetIndexBytesAsync(frameIndex, indexCompressedBytes);
-                using var indexDecompressedStream =
-                    new LzwDecompressStream(indexCompressedBytes, frame.ImageData.LzwMinimumCodeSize);
-                _cachedFrameBytes[frameIndex] = new byte[frame.Descriptor.Height][];
-                for (var row = 0; row < frame.Descriptor.Height; row++)
+			try
+			{
+                for (var frameIndex = 0; frameIndex < _metadata.Frames.Count; frameIndex++)
                 {
-                    _cachedFrameBytes[frameIndex][row] = new byte[frameDesc.Width];
-                    await indexDecompressedStream.ReadAllAsync(_cachedFrameBytes[frameIndex][row], 0, frameDesc.Width);
-                }
-            }
+                    if (cancellationToken.IsCancellationRequested)
+                    {
+                        _frameLoadedEvent.SetCanceled();
+						_frameLoadedEvent = null;
+                        return;
+                    }
+                    var frame = _metadata.Frames[frameIndex];
+                    var frameDesc = _metadata.Frames[frameIndex].Descriptor;
+                    await GetIndexBytesAsync(frameIndex, indexCompressedBytes);
+                    using var indexDecompressedStream =
+                        new LzwDecompressStream(indexCompressedBytes, frame.ImageData.LzwMinimumCodeSize);
+                    _cachedFrameBytes[frameIndex] = new byte[frame.Descriptor.Height][];
+                    for (var row = 0; row < frame.Descriptor.Height; row++)
+                    {
+                        _cachedFrameBytes[frameIndex][row] = new byte[frameDesc.Width];
+                        await indexDecompressedStream.ReadAllAsync(_cachedFrameBytes[frameIndex][row], 0, frameDesc.Width);
+                    }
+					NotifyOfFrameLoaded();
+				}
+			}
+			finally
+			{
+				_frameLoadedEvent?.SetResult(true);      
+				_frameLoadedEvent = null;
+			}
         }
 
         internal static async Task<TAnimator> CreateAsyncCore<TAnimator>(
@@ -165,8 +184,6 @@ namespace XamlAnimatedGif
         private int _frameIndex;
         private async Task RunAsync(CancellationToken cancellationToken)
         {
-            if(_loadFramesDataTask != null)
-                await _loadFramesDataTask;
             while (true)
             {
                 cancellationToken.ThrowIfCancellationRequested();
@@ -332,6 +349,7 @@ namespace XamlAnimatedGif
 
         private async Task RenderFrameAsync(int frameIndex, CancellationToken cancellationToken)
         {
+			await GetWaitLoadSingleFrameTask();
             if (frameIndex < 0)
                 return;
 
@@ -399,6 +417,23 @@ namespace XamlAnimatedGif
             _previousFrameIndex = frameIndex;
         }
 
+		private void NotifyOfFrameLoaded()
+		{
+			lock (_lockObject)
+			{
+				_frameLoadedEvent.SetResult(true);
+				_frameLoadedEvent = new TaskCompletionSource<bool>();
+			}
+		}
+		private Task GetWaitLoadSingleFrameTask()
+		{
+			if (_frameLoadedEvent == null)
+				return Task.CompletedTask; // avoiding lock statement if loading frames completed
+			lock (_lockObject)
+			{
+				return _frameLoadedEvent.Task ?? Task.CompletedTask;
+			}
+		}
         private static IEnumerable<int> NormalRows(int height)
         {
             return Enumerable.Range(0, height);
@@ -622,8 +657,6 @@ namespace XamlAnimatedGif
         {
             try
             {
-                if(_loadFramesDataTask != null)
-                    await _loadFramesDataTask;
                 await RenderFrameAsync(0, CancellationToken.None);
                 CurrentFrameIndex = 0;
                 _timingManager.Pause();

--- a/XamlAnimatedGif/BrushAnimator.cs
+++ b/XamlAnimatedGif/BrushAnimator.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Media;
 using System.Windows.Media.Animation;
@@ -9,7 +10,7 @@ namespace XamlAnimatedGif
 {
     public class BrushAnimator : Animator
     {
-        private BrushAnimator(Stream sourceStream, Uri sourceUri, GifDataStream metadata, RepeatBehavior repeatBehavior, bool cacheFrameDataInMemory) : base(sourceStream, sourceUri, metadata, repeatBehavior, cacheFrameDataInMemory)
+        private BrushAnimator(Stream sourceStream, Uri sourceUri, GifDataStream metadata, RepeatBehavior repeatBehavior, bool cacheFrameDataInMemory, CancellationToken cancellationToken) : base(sourceStream, sourceUri, metadata, repeatBehavior, cacheFrameDataInMemory, cancellationToken)
         {
             Brush = new ImageBrush {ImageSource = Bitmap};
             RepeatBehavior = _repeatBehavior;
@@ -34,27 +35,27 @@ namespace XamlAnimatedGif
 
         public static Task<BrushAnimator> CreateAsync(Uri sourceUri, RepeatBehavior repeatBehavior, IProgress<int> progress = null)
         {
-            return CreateAsync(sourceUri, repeatBehavior, false, progress);
+            return CreateAsync(sourceUri, repeatBehavior, false, CancellationToken.None, progress);
         }
 
-        public static Task<BrushAnimator> CreateAsync(Uri sourceUri, RepeatBehavior repeatBehavior, bool cacheFrameDataInMemory, IProgress<int> progress = null)
+        public static Task<BrushAnimator> CreateAsync(Uri sourceUri, RepeatBehavior repeatBehavior, bool cacheFrameDataInMemory, CancellationToken cancellationToken, IProgress<int> progress = null)
         {
             return CreateAsyncCore(
                 sourceUri,
                 progress,
-                (stream, metadata) => new BrushAnimator(stream, sourceUri, metadata, repeatBehavior, cacheFrameDataInMemory));
+                (stream, metadata) => new BrushAnimator(stream, sourceUri, metadata, repeatBehavior, cacheFrameDataInMemory, cancellationToken));
         }
 
         public static Task<BrushAnimator> CreateAsync(Stream sourceStream, RepeatBehavior repeatBehavior)
         {
-            return CreateAsync(sourceStream, repeatBehavior, false);
+            return CreateAsync(sourceStream, repeatBehavior, false, CancellationToken.None);
         }
 
-        public static Task<BrushAnimator> CreateAsync(Stream sourceStream, RepeatBehavior repeatBehavior, bool cacheFrameDataInMemory)
+        public static Task<BrushAnimator> CreateAsync(Stream sourceStream, RepeatBehavior repeatBehavior, bool cacheFrameDataInMemory, CancellationToken cancellationToken)
         {
             return CreateAsyncCore(
                 sourceStream,
-                metadata => new BrushAnimator(sourceStream, null, metadata, repeatBehavior, cacheFrameDataInMemory));
+                metadata => new BrushAnimator(sourceStream, null, metadata, repeatBehavior, cacheFrameDataInMemory,cancellationToken));
         }
     }
 }

--- a/XamlAnimatedGif/ImageAnimator.cs
+++ b/XamlAnimatedGif/ImageAnimator.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Controls;
 using System.Windows.Media.Animation;
@@ -12,11 +13,11 @@ namespace XamlAnimatedGif
         private readonly Image _image;
 
         public ImageAnimator(Stream sourceStream, Uri sourceUri, GifDataStream metadata, RepeatBehavior repeatBehavior,
-            Image image) : this(sourceStream, sourceUri, metadata, repeatBehavior, image, false)
+            Image image) : this(sourceStream, sourceUri, metadata, repeatBehavior, image, false, CancellationToken.None)
         {
         }
 
-        public ImageAnimator(Stream sourceStream, Uri sourceUri, GifDataStream metadata, RepeatBehavior repeatBehavior, Image image, bool cacheFrameDataInMemory) : base(sourceStream, sourceUri, metadata, repeatBehavior, cacheFrameDataInMemory)
+        public ImageAnimator(Stream sourceStream, Uri sourceUri, GifDataStream metadata, RepeatBehavior repeatBehavior, Image image, bool cacheFrameDataInMemory, CancellationToken cancellationToken) : base(sourceStream, sourceUri, metadata, repeatBehavior, cacheFrameDataInMemory, cancellationToken)
         {
             _image = image;
             OnRepeatBehaviorChanged(); // in case the value has changed during creation
@@ -28,26 +29,26 @@ namespace XamlAnimatedGif
 
         public static Task<ImageAnimator> CreateAsync(Uri sourceUri, RepeatBehavior repeatBehavior, IProgress<int> progress, Image image)
         {
-            return CreateAsync(sourceUri, repeatBehavior, progress, image, false);
+            return CreateAsync(sourceUri, repeatBehavior, progress, image, false, CancellationToken.None);
         }
 
-        public static Task<ImageAnimator> CreateAsync(Uri sourceUri, RepeatBehavior repeatBehavior, IProgress<int> progress, Image image, bool cacheFrameDataInMemory)
+        public static Task<ImageAnimator> CreateAsync(Uri sourceUri, RepeatBehavior repeatBehavior, IProgress<int> progress, Image image, bool cacheFrameDataInMemory, CancellationToken cancellationToken)
         {
             return CreateAsyncCore(
                 sourceUri,
                 progress,
-                (stream, metadata) => new ImageAnimator(stream, sourceUri, metadata, repeatBehavior, image, cacheFrameDataInMemory));
+                (stream, metadata) => new ImageAnimator(stream, sourceUri, metadata, repeatBehavior, image, cacheFrameDataInMemory, cancellationToken));
         }
 
         public static Task<ImageAnimator> CreateAsync(Stream sourceStream, RepeatBehavior repeatBehavior, Image image)
         {
             return CreateAsync(sourceStream, repeatBehavior, image);
         }
-        public static Task<ImageAnimator> CreateAsync(Stream sourceStream, RepeatBehavior repeatBehavior, Image image, bool cacheFrameDataInMemory)
+        public static Task<ImageAnimator> CreateAsync(Stream sourceStream, RepeatBehavior repeatBehavior, Image image, bool cacheFrameDataInMemory, CancellationToken cancellationToken)
         {
             return CreateAsyncCore(
                 sourceStream,
-                metadata => new ImageAnimator(sourceStream, null, metadata, repeatBehavior, image, cacheFrameDataInMemory));
+                metadata => new ImageAnimator(sourceStream, null, metadata, repeatBehavior, image, cacheFrameDataInMemory, cancellationToken));
         }
     }
 }


### PR DESCRIPTION
- Cancel LoadFrames background process on image unload
- Display animation frames as soon as they are loaded

1. I have added a CancellationTokenSource to the AnimationBehavior.InitAnimation method and attached an event handler to the image.Unloaded event. When the image is unloaded, the Cancel method is called. This change allows stopping the background thread responsible for loading gif frames, preventing unnecessary operations when the image is already unloaded or if the image source stream gets disposed.
2. I have implemented a TaskCompletionSource<bool> object named _frameLoadedEvent to facilitate communication between the LoadFrames method running in the background thread and the RenderFrameAsync method. This allows rendering a gif frame as soon as it is loaded, instead of waiting for all frames to load as it did previously. The new NotifyOfFrameLoaded method sets the TaskCompletionSource, and the new GetWaitLoadSingleFrameTask method returns a Task to be awaited on in the RenderFrameAsync method. NotifyOfFrameLoaded is called in LoadFrames as soon as a frame is loaded.