### PR TITLE
Fix issue on LZW decompression on certain GIFs

### DIFF
--- a/XamlAnimatedGif/Decompression/LzwDecompressStream.cs
+++ b/XamlAnimatedGif/Decompression/LzwDecompressStream.cs
@@ -11,7 +11,7 @@ namespace XamlAnimatedGif.Decompression
         private const int MaxCodeLength = 12;
         private readonly BitReader _reader;
         private readonly CodeTable _codeTable;
-        private int _prevCode;
+        private int _prevCode = -1;
         private byte[] _remainingBytes;
         private bool _endOfStream;
 


### PR DESCRIPTION
Certain GIFs failed to load due to an LZW decoding issue, as mentioned in #120.
The issue was failing to initialize the `_prevCode` member variable to `-1`.

I believe the LZW encoding in this case didn't 100% follow the rules.
Specifically, according to http://www.matthewflickinger.com/lab/whatsinagif/lzw_image_data.asp, the first code should be the 'clear code' - and in some GIFs that isn't the case.
If the first code is the 'clear code', the `_prevCode` member variable is immediately reset to `-1`, and everything works fine. If not, the `_prevCode` member variable gets the default value `0`, which causes the decoding to fail on certain first code values (so not always).

As mentioned above, this PR fixes #120.
After the change the GIF linked to the bug report loads properly, as do all other GIFs in the project.
