### PR TITLE
Clear Download Cache Location & Set & Get Cache File Time

### DIFF
--- a/XamlAnimatedGif.Demo/MainWindow.xaml.cs
+++ b/XamlAnimatedGif.Demo/MainWindow.xaml.cs
@@ -17,6 +17,8 @@ namespace XamlAnimatedGif.Demo
 
             //AnimationBehavior.SetDownloadCacheLocation(@"C:\GifCache"); //Path.GetTempPath()
 
+            //AnimationBehavior.SetCacheTime(TimeSpan.FromSeconds(30));
+
             //AnimationBehavior.ClearDownloadCacheLocation();
 
             _images = new ObservableCollection<string>

--- a/XamlAnimatedGif.Demo/MainWindow.xaml.cs
+++ b/XamlAnimatedGif.Demo/MainWindow.xaml.cs
@@ -17,6 +17,8 @@ namespace XamlAnimatedGif.Demo
 
             //AnimationBehavior.SetDownloadCacheLocation(@"C:\GifCache"); //Path.GetTempPath()
 
+            //AnimationBehavior.ClearDownloadCacheLocation();
+
             _images = new ObservableCollection<string>
                       {
                           "images/working.gif",

--- a/XamlAnimatedGif/AnimationBehavior.cs
+++ b/XamlAnimatedGif/AnimationBehavior.cs
@@ -10,7 +10,6 @@ using System.Windows.Markup;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Imaging;
 
-
 namespace XamlAnimatedGif
 {
     public static class AnimationBehavior
@@ -163,6 +162,20 @@ namespace XamlAnimatedGif
         public static string GetDownloadCacheLocation()
         {
             return UriLoader.DownloadCacheLocation;
+        }
+
+        public static void ClearDownloadCacheLocation()
+        {
+            string cachePath = UriLoader.DownloadCacheLocation;
+            if (Directory.Exists(cachePath))
+                foreach (string cacheFile in Directory.GetFiles(cachePath))
+                {
+                    try
+                    {
+                        File.Delete(cacheFile);
+                    }
+                    catch { }
+                }
         }
 
         public static void SetDownloadCacheLocation(string value)

--- a/XamlAnimatedGif/AnimationBehavior.cs
+++ b/XamlAnimatedGif/AnimationBehavior.cs
@@ -185,6 +185,20 @@ namespace XamlAnimatedGif
 
         #endregion
 
+        #region CacheTime
+
+        public static TimeSpan GetCacheTime()
+        {
+            return UriLoader.CacheTime;
+        }
+
+        public static void SetCacheTime(TimeSpan value)
+        {
+            UriLoader.CacheTime = value;
+        }
+
+        #endregion
+
         #region Animator
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]

--- a/XamlAnimatedGif/UriLoader.cs
+++ b/XamlAnimatedGif/UriLoader.cs
@@ -14,6 +14,7 @@ namespace XamlAnimatedGif
     internal class UriLoader
     {
         public static string DownloadCacheLocation { get; set; } = Path.GetTempPath();
+        public static TimeSpan CacheTime { get; set; } = TimeSpan.FromHours(12);
 
         public static Task<Stream> GetStreamFromUriAsync(Uri uri, IProgress<int> progress)
         {
@@ -94,9 +95,16 @@ namespace XamlAnimatedGif
                 Directory.CreateDirectory(DownloadCacheLocation);
             string path = Path.Combine(DownloadCacheLocation, fileName);
             Stream stream = null;
+            DateTime time;
             try
             {
-                stream = File.OpenRead(path);
+                time = File.GetLastWriteTime(path);
+
+                if (DateTime.Now - time < CacheTime)
+                {
+                    stream = File.OpenRead(path);
+                }
+
             }
             catch (FileNotFoundException)
             {


### PR DESCRIPTION
In the changes made, briefly,  `AnimationBehavior.ClearDownloadCacheLocation()` now clears the temporary file directory.